### PR TITLE
Update requirements-debian-12-arm64.txt

### DIFF
--- a/cfg/requirements-debian-12-arm64.txt
+++ b/cfg/requirements-debian-12-arm64.txt
@@ -79,13 +79,13 @@ platformdirs==4.3.7
 pluggy==1.5.0
 protobuf==6.30.2
 psutil==7.0.0
-pycairo==1.27.0
+pycairo==1.28.0
 pycocotools==2.0.8
 pydantic==2.8.2
 pydantic_core==2.20.1
 pyglet==2.1.3
 Pygments==2.19.1
-PyGObject==3.50.0
+PyGObject==3.52.1
 pyopencl==2025.1
 pyparsing==3.2.3
 pyquaternion==0.9.9
@@ -112,7 +112,7 @@ strictyaml==1.7.3
 sympy==1.13.3
 tomli==2.2.1
 torch==1.13.1
-torchvision==0.14.1
+torchvision==0.22.0
 tornado==6.4.2
 tqdm==4.67.1
 traitlets==5.14.3


### PR DESCRIPTION
bump pycairo to v 1.28.0
bump pyobjeects to v 3.52.1
bump torchvision to v 0.22.0